### PR TITLE
Enhance abi encoder

### DIFF
--- a/lib/abi.js
+++ b/lib/abi.js
@@ -15,16 +15,22 @@ const Bytes = require("./bytes");
 const Nat = require("./nat");
 const keccak256s = require("./hash").keccak256s;
 
+const isString = (s) => {
+  return typeof(s) === 'string' || s instanceof String;
+}
+
 // (type : String), JSType(type) -> {data: Bytes, dynamic: Bool}
 //   ABI-encodes a single term.
 const encode = (type, value) => {
+  if (!isString(value)) value = Number(value).toString(16);
+  if (!value.startsWith('0x')) value = '0x' + value;
   if (type === "bytes") {
     const length = Bytes.length(value);
     const nextMul32 = (((length - 1) / 32 | 0) + 1) * 32;
     const lengthEncoded = encode("uint256", Nat.fromNumber(length)).data;
     const bytesEncoded = Bytes.padRight(nextMul32, value);
     return { data: Bytes.concat(lengthEncoded, bytesEncoded), dynamic: true };
-  } else if (type === "uint256" || type === "bytes32" || type === "address") {
+  } else if (type === "uint256" || type === "bytes32" || type === "address" || type === "bool") {
     return { data: Bytes.pad(32, value), dynamic: false };
   } else {
     throw "Eth-lib can't encode ABI type " + type + " yet.";

--- a/lib/abi.js
+++ b/lib/abi.js
@@ -22,16 +22,17 @@ const isString = (s) => {
 // (type : String), JSType(type) -> {data: Bytes, dynamic: Bool}
 //   ABI-encodes a single term.
 const encode = (type, value) => {
-  if (!isString(value)) value = Number(value).toString(16);
-  if (!value.startsWith('0x')) value = '0x' + value;
+  if (isString(value) && !value.startsWith('0x')) value = '0x' + value;
   if (type === "bytes") {
     const length = Bytes.length(value);
     const nextMul32 = (((length - 1) / 32 | 0) + 1) * 32;
     const lengthEncoded = encode("uint256", Nat.fromNumber(length)).data;
     const bytesEncoded = Bytes.padRight(nextMul32, value);
     return { data: Bytes.concat(lengthEncoded, bytesEncoded), dynamic: true };
-  } else if (type === "uint256" || type === "bytes32" || type === "address" || type === "bool") {
+  } else if (type === "uint256" || type === "bytes32" || type === "address") {
     return { data: Bytes.pad(32, value), dynamic: false };
+  } else if (type === "bool") {
+    return { data: Bytes.pad(32, value ? "0x1" : "0x0"), dynamic: false };
   } else {
     throw "Eth-lib can't encode ABI type " + type + " yet.";
   }


### PR DESCRIPTION
- Add support to encode bool type
- Add support to encode number type (not hex string)
- Add support to missing `0x` prefix to hex string